### PR TITLE
Added free courses from Kaggle for data science

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The offers on top of the table are time-limited and will expire soon. So, hurry 
 | Cilium | Isovalent | Cilium IPv6 Networking and Observability | [Link](https://isovalent.com/labs/ipv6-networking-and-observability/) | Unknown |
 | Cilium | Isovalent | Cilium Gateway API | [Link](https://isovalent.com/labs/gateway-api/) | Unknown |
 | AWS Skill Builder | AWS | AWS Skill Builder is a repository of over 700 training lessons to help you learn AWS and refine your knowledge of AWS services and improve your skills so you can put them into practice or apply the knowledge during the many AWS certifications. | [Link](https://explore.skillbuilder.aws/learn/catalog) | Unknwon |
+| Data Science | Kaggle | 17 Free courses on the fundamentals of Data Science such as Python, Pandas, SQL, Data Visualization, Deep Learning, etc. | [Link](https://www.kaggle.com/learn) | Unknown |
 
 
 


### PR DESCRIPTION
Kaggle offers free data science courses for those interested in learning things such as Python, Pandas, Computer Vision, etc.